### PR TITLE
feat: Save and load control port in project files

### DIFF
--- a/src/sequencer/sequencer.py
+++ b/src/sequencer/sequencer.py
@@ -1199,6 +1199,7 @@ class Sequencer:
             project_data = {
                 "song": self.song,
                 "virtual_ports": [vp.name for vp in self.virtual_ports],
+                "control_port_name": self.control_port_name,
                 "audio_player_command": self.audio_player_command,
             }
             with open(project_filepath, 'w') as f:
@@ -1233,6 +1234,12 @@ class Sequencer:
             for vp_name in project_data.get("virtual_ports", []):
                 self.create_virtual_port(vp_name)
 
+            # Restore control port
+            self.unset_control_port()
+            control_port_name = project_data.get("control_port_name")
+            if control_port_name:
+                self.set_control_port(control_port_name)
+
             self.is_dirty = False
             self.last_project_basename = basename
             print(f"Successfully loaded project from '{project_filepath}'")
@@ -1240,6 +1247,21 @@ class Sequencer:
             print(f"Error: Project file not found at '{project_filepath}'")
         except Exception as e:
             print(f"Error loading project file: {e}")
+
+    def new_project(self):
+        """Resets the sequencer to a new, empty project."""
+        if self.playback_state != "stopped":
+            self.stop()
+            if self.playback_thread and self.playback_thread.is_alive():
+                self.playback_thread.join()
+
+        self.song = Song(name="New Song", tempo=120)
+        self.close_virtual_ports()
+        self.virtual_ports = []
+        self.unset_control_port()
+        self.last_project_basename = None
+        self.is_dirty = False
+        print("New project created.")
 
     def list_tracks(self) -> str:
         if not self.song.tracks:
@@ -1482,7 +1504,11 @@ class Sequencer:
 
         outport_name = target_track.output_port_name
         original_mute_state = target_track.is_muted
-        target_track.is_muted = True
+        if replace_notes:
+            target_track.is_muted = True
+        # When overdubbing (not replacing), we don't mute the track so the user can hear existing notes.
+        # The playback engine uses a snapshot of events from before recording started,
+        # and new notes are passed through via the recording thread's MIDI thru.
 
         self.is_recording = True
         self.recording_thread = threading.Thread(


### PR DESCRIPTION
This commit implements the functionality to save the `control_port_name` when a project is saved and to restore it when a project is loaded.

The `save_project` method in `src/sequencer/sequencer.py` has been updated to include the `control_port_name` in the project's JSON file.

The `load_project` method has been updated to read this value and re-initialize the control port listener. This includes unsetting any previously active listener to prevent conflicts.

Additionally, two unrelated issues in the test suite were fixed to ensure all tests pass:
- Added a `new_project` method to the `Sequencer` class, which was missing but required by `tests/test_sequencer.py`.
- Corrected the logic in `_start_recording_internal` to only mute the track when replacing notes, not when overdubbing, fixing the `test_overdub_does_not_mute` test.