### PR TITLE
Fix Scrolling Saccades with Audio Tracks

### DIFF
--- a/src/sequencer/jack_manager.py
+++ b/src/sequencer/jack_manager.py
@@ -13,8 +13,8 @@ import threading
 import time
 import collections
 from contextlib import contextmanager
-from dataclasses import dataclass
-from typing import List, Optional, TYPE_CHECKING, Dict
+from dataclasses import dataclass, field
+from typing import List, Optional, TYPE_CHECKING, Dict, Any
 
 from kivy.clock import Clock
 
@@ -31,6 +31,25 @@ class ActiveAudioProcess:
     track_index: int
     temp_filepath: Optional[str] = None # No longer mixing to a temp file
 
+@dataclass
+class TrackSnapshot:
+    index: int
+    name: str
+    is_midi: bool = False
+    is_audio: bool = False
+    is_automation: bool = False
+    target_track_index: int = -1
+    points: List[Any] = field(default_factory=list)
+    start_time: float = 0.0
+    duration_beats: float = 0.0
+    channel: int = 0
+    output_port_name: Optional[str] = None
+    socket_path: Optional[str] = None
+    is_muted: bool = False
+    is_solo: bool = False
+    velocity: float = 1.0
+    instrument: int = 0
+    events: List[Any] = field(default_factory=list)
 
 class JackManager:
     def __init__(self, sequencer: 'Sequencer'):
@@ -52,6 +71,12 @@ class JackManager:
         self.next_automation_event_index = 0
         self.event_to_ignore: Optional[dict] = None
         self._routing_track: Optional[AutomationTrack] = None        
+        self._track_snapshots: List[TrackSnapshot] = []
+
+        # --- RT-safe IPC Command Queue ---
+        self._ipc_queue = collections.deque(maxlen=100)
+        self._ipc_worker_thread = None
+        self._ipc_worker_stop_event = threading.Event()
 
         # --- UI Command Flags (from MIDI) ---
         self._pending_play_pause = False
@@ -283,8 +308,9 @@ class JackManager:
 
                     if last_speed is None or not math.isclose(last_speed, new_speed, rel_tol=1e-4):
                         command = {"command": ["set_property", "speed", new_speed]}
-                        if self._send_ipc_command(ap.socket_path, command):
-                            self.last_applied_speeds[ap.track_index] = new_speed
+                        # Use the queue for speed changes too to keep things uniform
+                        self._queue_ipc_command(ap.socket_path, command)
+                        self.last_applied_speeds[ap.track_index] = new_speed
 
             except jack.JackError:
                 # This can happen during shutdown, it's safe to just exit the loop
@@ -353,6 +379,82 @@ class JackManager:
                         self.automation_events.extend(generated)
 
         self.automation_events.sort(key=lambda e: e['time'])
+
+    def _ipc_worker_loop(self):
+        """Background thread to process mpv IPC commands without blocking RT thread."""
+        while not self._ipc_worker_stop_event.is_set():
+            try:
+                if self._ipc_queue:
+                    socket_path, command_data = self._ipc_queue.popleft()
+                    self._send_ipc_command(socket_path, command_data)
+                else:
+                    time.sleep(0.01)
+            except IndexError:
+                time.sleep(0.01)
+            except Exception as e:
+                print(f"Error in IPC worker loop: {e}", file=sys.stderr)
+
+    def _queue_ipc_command(self, socket_path: str, command_data: dict):
+        """Queues an IPC command to be sent by the background worker."""
+        if socket_path:
+            self._ipc_queue.append((socket_path, command_data))
+
+    def refresh_automation(self):
+        """Updates the cached automation events and track snapshots for the audio thread."""
+        self._prepare_automation_events()
+
+        # Take a snapshot of song global properties
+        self._rt_tempo = self.sequencer.song.tempo
+        self._rt_beats_per_measure = self.sequencer.song.time_signature_numerator
+
+        # Take a snapshot of metronome state
+        self._rt_metronome_enabled = self.sequencer.song.metronome_enabled
+        self._rt_metronome_port_name = self.sequencer.song.metronome_port_name
+        self._rt_metronome_channel = self.sequencer.metronome_channel
+        self._rt_metronome_pitch_downbeat = self.sequencer.metronome_pitch_downbeat
+        self._rt_metronome_pitch_beat = self.sequencer.metronome_pitch_beat
+        self._rt_metronome_volume = self.sequencer.song.metronome_volume
+        self._rt_metronome_pan = self.sequencer.song.metronome_pan
+
+        # Take a snapshot of tracks for RT-safe access
+        new_snapshots = []
+        tracks = self.sequencer.song.tracks
+
+        # Pre-calculate audio durations if needed
+        for i, track in enumerate(tracks):
+            if isinstance(track, AudioTrack):
+                self.sequencer._get_audio_duration_in_beats(track)
+
+        for i, track in enumerate(tracks):
+            # --- Live Preview Override ---
+            if i in self.sequencer.track_overrides:
+                track = self.sequencer.track_overrides[i]
+
+            snap = TrackSnapshot(index=i, name=track.name)
+            if isinstance(track, MidiTrack):
+                snap.is_midi = True
+                snap.channel = track.channel
+                snap.output_port_name = track.output_port_name
+                snap.events = track.events
+                snap.velocity = track.velocity
+                snap.instrument = track.instrument
+            elif isinstance(track, AudioTrack):
+                snap.is_audio = True
+                snap.start_time = track.start_time
+                snap.duration_beats = track.duration_beats or 0.0
+                ap = next((p for p in self.active_audio_processes if p.track_index == i), None)
+                if ap:
+                    snap.socket_path = ap.socket_path
+            elif isinstance(track, AutomationTrack):
+                snap.is_automation = True
+                snap.target_track_index = track.target_track_index
+                snap.points = track.points # Shared list
+
+            snap.is_muted = getattr(track, 'is_muted', False)
+            snap.is_solo = getattr(track, 'is_solo', False)
+            new_snapshots.append(snap)
+
+        self._track_snapshots = new_snapshots
 
     def start(self):
             if self.is_running:
@@ -437,8 +539,17 @@ class JackManager:
 
                 self.jack_client.set_process_callback(self._process_callback)
                 self.jack_client.set_timebase_callback(self._time_callback)
+
+                # --- Start IPC worker thread ---
+                self._ipc_worker_stop_event.clear()
+                self._ipc_worker_thread = threading.Thread(target=self._ipc_worker_loop)
+                self._ipc_worker_thread.daemon = True
+                self._ipc_worker_thread.start()
+
                 self.jack_client.activate()
                 self.is_running = True
+
+                self.refresh_automation()
 
                 # --- Initial Transport Sync ---
                 state, pos_struct = self.jack_client.transport_query_struct()
@@ -478,6 +589,12 @@ class JackManager:
         """Stops the JACK client, its threads, and all related processes."""
         if not self.is_running:
             return
+
+        # Stop the IPC worker thread
+        if self._ipc_worker_thread and self._ipc_worker_thread.is_alive():
+            self._ipc_worker_stop_event.set()
+            self._ipc_worker_thread.join(timeout=1.0)
+            self._ipc_worker_thread = None
 
         # Stop the display thread if it's running
         if self._display_thread and self._display_thread.is_alive():
@@ -609,11 +726,19 @@ class JackManager:
         except (socket.timeout, ConnectionRefusedError, FileNotFoundError):
             return False
 
-    def set_all_audio_pause_state(self, is_paused: bool):
-        with self.process_lock:
-            for ap in self.active_audio_processes:
-                command = {"command": ["set_property", "pause", is_paused]}
-                self._send_ipc_command(ap.socket_path, command)
+    def set_all_audio_pause_state(self, is_paused: bool, rt_safe=False):
+        """Sets the pause state for all audio tracks. If rt_safe is True, it uses the async queue."""
+        if rt_safe:
+            snapshots = self._track_snapshots
+            for snap in snapshots:
+                if snap.is_audio:
+                    command = {"command": ["set_property", "pause", is_paused]}
+                    self._queue_ipc_command(snap.socket_path, command)
+        else:
+            with self.process_lock:
+                for ap in self.active_audio_processes:
+                    command = {"command": ["set_property", "pause", is_paused]}
+                    self._send_ipc_command(ap.socket_path, command)
 
     def launch_player_for_track(self, track: AudioTrack, track_index: int):
         """Launches, waits for, and primes a player for a single audio track."""
@@ -838,38 +963,34 @@ class JackManager:
                 self.sequencer.last_beat_update_time = time.perf_counter()
 
     def _process_midi_events(self, start_beat_of_block, end_beat_of_block):
-        tracks = self.sequencer.song.tracks
-        is_any_track_soloed = any(t.is_solo for t in tracks if hasattr(t, 'is_solo'))
+        snapshots = self._track_snapshots
+        is_any_track_soloed = any(s.is_solo for s in snapshots)
 
-        for i, track in enumerate(tracks):
-            # --- Live Preview Override ---
-            # If a track is being edited, use the temporary version from the editor.
-            if i in self.sequencer.track_overrides:
-                track = self.sequencer.track_overrides[i]
-
-            if not isinstance(track, MidiTrack) or not track.output_port_name in self.open_ports:
+        for i, snap in enumerate(snapshots):
+            if not snap.is_midi or not snap.output_port_name in self.open_ports:
                 continue
 
-            should_be_audible = (track.is_solo or not is_any_track_soloed) and not track.is_muted
-            port = self.open_ports[track.output_port_name]
+            should_be_audible = (snap.is_solo or not is_any_track_soloed) and not snap.is_muted
+            port = self.open_ports[snap.output_port_name]
 
             if i >= len(self.next_event_indices):
                 self.next_event_indices.extend([0] * (i - len(self.next_event_indices) + 1))
 
-            while self.next_event_indices[i] < len(track.events):
-                event = track.events[self.next_event_indices[i]]
+            events = snap.events
+            while self.next_event_indices[i] < len(events):
+                event = events[self.next_event_indices[i]]
 
                 if start_beat_of_block <= event.start_time < end_beat_of_block:
                     if should_be_audible:
                         for note in event.notes:
-                            final_velocity = int(note.velocity * track.velocity)
+                            final_velocity = int(note.velocity * snap.velocity)
                             final_velocity = max(0, min(127, final_velocity))
-                            note_on_msg = mido.Message('note_on', channel=track.channel, note=note.pitch, velocity=final_velocity)
+                            note_on_msg = mido.Message('note_on', channel=snap.channel, note=note.pitch, velocity=final_velocity)
                             port.send(note_on_msg)
                             note_end_beat = event.start_time + note.duration
                             self._active_notes[(i, note.pitch)] = note_end_beat
                         for cc in event.cc_messages:
-                            cc_msg = mido.Message('control_change', channel=track.channel, control=cc.control, value=cc.value)
+                            cc_msg = mido.Message('control_change', channel=snap.channel, control=cc.control, value=cc.value)
                             port.send(cc_msg)
                     self.next_event_indices[i] += 1
                 elif event.start_time >= end_beat_of_block:
@@ -887,16 +1008,18 @@ class JackManager:
         primed_params = set()
         param_map = {"vol": {"type": "midi_cc", "control": 7}, "pan": {"type": "midi_cc", "control": 10}, "vel": {"type": "velocity_multiplier"}, "prog": {"type": "program_change"}, **{f"cc{i}": {"type": "midi_cc", "control": i} for i in range(128)}}
 
-        for track in self.sequencer.song.tracks:
-            if not isinstance(track, AutomationTrack):
+        snapshots = self._track_snapshots
+
+        for snap in snapshots:
+            if not snap.is_automation:
                 continue
 
             # This logic only works if the target track is valid
-            if not 0 <= track.target_track_index < len(self.sequencer.song.tracks):
+            if not 0 <= snap.target_track_index < len(snapshots):
                 continue
 
             points_by_parameter: Dict[str, List[AutomationPoint]] = {}
-            for p in track.points:
+            for p in snap.points:
                 points_by_parameter.setdefault(p.parameter, []).append(p)
 
             for parameter, points in points_by_parameter.items():
@@ -947,32 +1070,33 @@ class JackManager:
                 param_config = param_map.get(parameter.lower())
                 if param_config:
                     event_dict = {
-                        "target_track_index": track.target_track_index,
+                        "target_track_index": snap.target_track_index,
                         "parameter": parameter,
                         "param_config": param_config,
                         "value": value_to_apply
                     }
                     self._apply_automation_event(event_dict)
-                    primed_params.add((track.target_track_index, parameter))
+                    primed_params.add((snap.target_track_index, parameter))
 
         return primed_params
 
     def _apply_automation_event(self, event: dict):
         """Applies a single automation event."""
         target_track_index = event['target_track_index']
-        if not 0 <= target_track_index < len(self.sequencer.song.tracks):
+        snapshots = self._track_snapshots
+        if not 0 <= target_track_index < len(snapshots):
             return
 
-        target_track = self.sequencer.song.tracks[target_track_index]
+        snap = snapshots[target_track_index]
         param_config = event['param_config']
         value = event['value']
         param_name = event['parameter'].lower()
 
         # Branch by Track Type first for clarity and correctness
-        if isinstance(target_track, MidiTrack):
+        if snap.is_midi:
             if param_config.get('type') == 'midi_cc':
-                if target_track.output_port_name in self.open_ports:
-                    port = self.open_ports[target_track.output_port_name]
+                if snap.output_port_name in self.open_ports:
+                    port = self.open_ports[snap.output_port_name]
                     midi_value = 0
                     if param_name == 'vol':
                         midi_value = int(value * 127)
@@ -984,34 +1108,34 @@ class JackManager:
                     # --- FIX: Clamp the final value to the valid MIDI range ---
                     midi_value = max(0, min(127, midi_value))
 
-                    msg = mido.Message('control_change', channel=target_track.channel, control=param_config['control'], value=midi_value)
+                    msg = mido.Message('control_change', channel=snap.channel, control=param_config['control'], value=midi_value)
                     port.send(msg)
             elif param_config.get('type') == 'program_change':
-                if target_track.output_port_name in self.open_ports:
-                    port = self.open_ports[target_track.output_port_name]
+                if snap.output_port_name in self.open_ports:
+                    port = self.open_ports[snap.output_port_name]
                     program_value = max(0, min(127, int(value)))
-                    msg = mido.Message('program_change', channel=target_track.channel, program=program_value)
+                    msg = mido.Message('program_change', channel=snap.channel, program=program_value)
                     port.send(msg)
             elif param_config.get('type') == 'velocity_multiplier':
-                target_track.velocity = float(value)
+                snap.velocity = float(value)
 
-        elif isinstance(target_track, AudioTrack):
-            ap = next((p for p in self.active_audio_processes if p.track_index == target_track_index), None)
-            if not ap:
+        elif snap.is_audio:
+            socket_path = snap.socket_path
+            if not socket_path:
                 return
 
             if param_name == 'vol':
                 # mpv expects volume from 0 to 100
                 mpv_volume = value * 100
                 command = {"command": ["set_property", "volume", mpv_volume]}
-                self._send_ipc_command(ap.socket_path, command)
+                self._queue_ipc_command(socket_path, command)
             elif param_name == 'pan':
                 # CORRECT: Use the lavfi filter for audio track panning, not 'balance'
                 gain_l = min(1.0, 1.0 - value)
                 gain_r = min(1.0, 1.0 + value)
                 pan_filter = f"lavfi=[pan=stereo|c0={gain_l:.2f}*c0|c1={gain_r:.2f}*c1]"
                 command = {"command": ["set_property", "af", pan_filter]}
-                self._send_ipc_command(ap.socket_path, command)
+                self._queue_ipc_command(socket_path, command)
 
     def _process_automation_events(self, start_beat_of_block, end_beat_of_block):
         while self.next_automation_event_index < len(self.automation_events):
@@ -1025,26 +1149,26 @@ class JackManager:
                 self.next_automation_event_index += 1
 
     def _process_metronome(self, start_beat_of_block, end_beat_of_block):
-        if self.sequencer.song.metronome_enabled and self.sequencer.song.metronome_port_name in self.open_ports:
-            port = self.open_ports[self.sequencer.song.metronome_port_name]
+        if getattr(self, '_rt_metronome_enabled', False) and self._rt_metronome_port_name in self.open_ports:
+            port = self.open_ports[self._rt_metronome_port_name]
             beat_to_check = math.ceil(start_beat_of_block)
 
             if beat_to_check < end_beat_of_block:
-                midi_pan = int((self.sequencer.song.metronome_pan + 1.0) / 2.0 * 127)
-                port.send(mido.Message('control_change', channel=self.sequencer.metronome_channel, control=10, value=midi_pan))
+                midi_pan = int((self._rt_metronome_pan + 1.0) / 2.0 * 127)
+                port.send(mido.Message('control_change', channel=self._rt_metronome_channel, control=10, value=midi_pan))
 
             while beat_to_check < end_beat_of_block:
-                beats_per_measure = self.sequencer.song.time_signature_numerator
+                beats_per_measure = getattr(self, '_rt_beats_per_measure', 4)
                 is_downbeat = (int(beat_to_check) % beats_per_measure) == 0 if beats_per_measure > 0 else beat_to_check == 0
-                pitch = self.sequencer.metronome_pitch_downbeat if is_downbeat else self.sequencer.metronome_pitch_beat
-                velocity = int(100 * self.sequencer.song.metronome_volume)
-                note_on = mido.Message('note_on', channel=self.sequencer.metronome_channel, note=pitch, velocity=velocity)
-                note_off = mido.Message('note_off', channel=self.sequencer.metronome_channel, note=pitch, velocity=0)
+                pitch = self._rt_metronome_pitch_downbeat if is_downbeat else self._rt_metronome_pitch_beat
+                velocity = int(100 * self._rt_metronome_volume)
+                note_on = mido.Message('note_on', channel=self._rt_metronome_channel, note=pitch, velocity=velocity)
+                note_off = mido.Message('note_off', channel=self._rt_metronome_channel, note=pitch, velocity=0)
                 port.send(note_on)
                 self._metronome_notes_to_turn_off.append(note_off)
                 beat_to_check += 1
 
-    def _check_for_loop_and_play_range(self, start_beat_of_block, end_beat_of_block):
+    def _check_for_loop_and_play_range(self, start_beat_of_block, end_beat_of_block, pos_struct: Any):
         if self.sequencer.play_range_enabled and end_beat_of_block >= self.sequencer.play_range_end_beat:
             if start_beat_of_block < self.sequencer.play_range_end_beat:
                 # Schedule the stop command to be executed on the main thread
@@ -1056,34 +1180,41 @@ class JackManager:
                 # When looping, re-prime automation to the loop start point
                 self._prime_automation_at_beat(self.sequencer.loop_start_beat)
 
-                beats_per_second = self.sequencer.song.tempo / 60.0
+                beats_per_second = getattr(self, '_rt_tempo', 120) / 60.0
                 samplerate = self.jack_client.samplerate
                 if beats_per_second > 0 and samplerate > 0:
                     target_frame = int((self.sequencer.loop_start_beat / beats_per_second) * samplerate)
-                    _ , pos = self.jack_client.transport_query_struct()
-                    pos.frame = target_frame
-                    self.jack_client.transport_reposition_struct(pos)
+                    # RT Safe: Use the passed pos_struct
+                    pos_struct.frame = target_frame
+                    self.jack_client.transport_reposition_struct(pos_struct)
 
-        song_length_beats = self.sequencer.get_song_length_in_beats()
+        # song_length_beats should be cached in Sequencer
+        song_length_beats = self.sequencer._cached_song_length_beats or self.sequencer.get_song_length_in_beats()
         
         if not self.sequencer.loop_enabled and not self.sequencer.is_recording and song_length_beats > 0 and end_beat_of_block >= song_length_beats:
             if start_beat_of_block < song_length_beats:
                 self.jack_client.transport_stop()
-                self.sequencer.playback_state = "stopped"
+                # playback_state is a Kivy property, but setting it here might be okay as it's atomic-ish
+                # (but better to use Clock.schedule_once if we want to be 100% strict,
+                # however Sequencer._poll_engine_state will handle it anyway)
 
-    def _process_callback(self, frames: int):
+    def _process_callback(self, frames: int, pos_struct: Any):
         try:
             current_transport_state = self.jack_client.transport_state
             if current_transport_state != self.last_transport_state:
                 if current_transport_state == jack.ROLLING:
-                    self.set_all_audio_pause_state(False)
+                    self.set_all_audio_pause_state(False, rt_safe=True)
                 else: # STOPPED or other state
-                    self.set_all_audio_pause_state(True)
+                    self.set_all_audio_pause_state(True, rt_safe=True)
                 self.last_transport_state = current_transport_state
 
             with self.sync_lock:
-                if self.sequencer.song.metronome_enabled and self.sequencer.song.metronome_port_name in self.open_ports:
-                    port = self.open_ports[self.sequencer.song.metronome_port_name]
+                # Use snapshots for everything in the process callback
+                snapshots = self._track_snapshots
+
+                metronome_port_name = getattr(self, '_rt_metronome_port_name', None)
+                if getattr(self, '_rt_metronome_enabled', False) and metronome_port_name in self.open_ports:
+                    port = self.open_ports[metronome_port_name]
                     for note_off_msg in self._metronome_notes_to_turn_off:
                         port.send(note_off_msg)
                     self._metronome_notes_to_turn_off.clear()
@@ -1091,17 +1222,18 @@ class JackManager:
                 if not self.jack_client or self.jack_client.transport_state != jack.ROLLING:
                     if self._active_notes:
                         for (track_idx, pitch), end_beat in list(self._active_notes.items()):
-                            track = self.sequencer.song.tracks[track_idx]
-                            if isinstance(track, MidiTrack) and track.output_port_name in self.open_ports:
-                                port = self.open_ports[track.output_port_name]
-                                port.send(mido.Message('note_off', channel=track.channel, note=pitch, velocity=0))
+                            if 0 <= track_idx < len(snapshots):
+                                snap = snapshots[track_idx]
+                                if snap.is_midi and snap.output_port_name in self.open_ports:
+                                    port = self.open_ports[snap.output_port_name]
+                                    port.send(mido.Message('note_off', channel=snap.channel, note=pitch, velocity=0))
                         self._active_notes.clear()
                     return
 
-            state, pos_struct = self.jack_client.transport_query_struct()
+            # RT Safe: Use the provided pos_struct instead of transport_query_struct()
             pos = jack.position2dict(pos_struct)
             samplerate = self.jack_client.samplerate
-            tempo = self.sequencer.song.tempo
+            tempo = getattr(self, '_rt_tempo', 120)
             beats_per_second = tempo / 60.0
 
             start_beat_of_block = self.last_beat
@@ -1116,27 +1248,26 @@ class JackManager:
 
             for (track_idx, pitch), end_beat in list(self._active_notes.items()):
                 if start_beat_of_block <= end_beat < end_beat_of_block:
-                    track = self.sequencer.song.tracks[track_idx]
-                    if isinstance(track, MidiTrack) and track.output_port_name in self.open_ports:
-                        port = self.open_ports[track.output_port_name]
-                        port.send(mido.Message('note_off', channel=track.channel, note=pitch, velocity=0))
+                    if 0 <= track_idx < len(snapshots):
+                        snap = snapshots[track_idx]
+                        if snap.is_midi and snap.output_port_name in self.open_ports:
+                            port = self.open_ports[snap.output_port_name]
+                            port.send(mido.Message('note_off', channel=snap.channel, note=pitch, velocity=0))
                     del self._active_notes[(track_idx, pitch)]
 
             self._process_midi_events(start_beat_of_block, end_beat_of_block)
             self._process_automation_events(start_beat_of_block, end_beat_of_block)
             self._process_metronome(start_beat_of_block, end_beat_of_block)
 
-            with self.process_lock:
-                for ap in self.active_audio_processes:
-                    track = self.sequencer.song.tracks[ap.track_index]
-                    if isinstance(track, AudioTrack):
-                        duration_beats = self.sequencer._get_audio_duration_in_beats(track)
-                        end_beat = track.start_time + duration_beats
-                        if end_beat_of_block >= end_beat and start_beat_of_block < end_beat:
-                            command = {"command": ["set_property", "pause", True]}
-                            self._send_ipc_command(ap.socket_path, command)
+            # Process audio track end-of-track pausing via snapshots and queue
+            for snap in snapshots:
+                if snap.is_audio:
+                    end_beat = snap.start_time + snap.duration_beats
+                    if end_beat_of_block >= end_beat and start_beat_of_block < end_beat:
+                        command = {"command": ["set_property", "pause", True]}
+                        self._queue_ipc_command(snap.socket_path, command)
 
-            self._check_for_loop_and_play_range(start_beat_of_block, end_beat_of_block)
+            self._check_for_loop_and_play_range(start_beat_of_block, end_beat_of_block, pos_struct)
 
             self.last_beat = end_beat_of_block
             #if self.sequencer.gui_mode:

--- a/src/sequencer/jack_manager.py
+++ b/src/sequencer/jack_manager.py
@@ -64,7 +64,6 @@ class JackManager:
         self._metronome_notes_to_turn_off = []
         self.active_audio_processes: List[ActiveAudioProcess] = []
         self.process_lock = threading.Lock()
-        self.sync_lock = threading.Lock()
         self._display_thread = None
         self._display_stop_event = threading.Event()
         self.automation_events = []
@@ -97,6 +96,7 @@ class JackManager:
         #self._diag_last_target_idx = -1
         self._last_beat_rt = 0.0 # Atomic float for UI sync
         self._last_transport_state_rt = jack.STOPPED        
+        self._paused_audio_tracks = set() # To avoid redundant IPC commands in RT thread
 
     def find_port_by_name(self, pattern):
         """
@@ -415,6 +415,9 @@ class JackManager:
         self._rt_metronome_pitch_beat = self.sequencer.metronome_pitch_beat
         self._rt_metronome_volume = self.sequencer.song.metronome_volume
         self._rt_metronome_pan = self.sequencer.song.metronome_pan
+
+        # Take a snapshot of song length for RT-safe end detection
+        self._rt_song_length_beats = self.sequencer._cached_song_length_beats or self.sequencer.get_song_length_in_beats()
 
         # Take a snapshot of tracks for RT-safe access
         new_snapshots = []
@@ -1168,7 +1171,7 @@ class JackManager:
                 self._metronome_notes_to_turn_off.append(note_off)
                 beat_to_check += 1
 
-    def _check_for_loop_and_play_range(self, start_beat_of_block, end_beat_of_block, pos_struct: Any):
+    def _check_for_loop_and_play_range(self, start_beat_of_block, end_beat_of_block):
         if self.sequencer.play_range_enabled and end_beat_of_block >= self.sequencer.play_range_end_beat:
             if start_beat_of_block < self.sequencer.play_range_end_beat:
                 # Schedule the stop command to be executed on the main thread
@@ -1184,12 +1187,13 @@ class JackManager:
                 samplerate = self.jack_client.samplerate
                 if beats_per_second > 0 and samplerate > 0:
                     target_frame = int((self.sequencer.loop_start_beat / beats_per_second) * samplerate)
-                    # RT Safe: Use the passed pos_struct
-                    pos_struct.frame = target_frame
-                    self.jack_client.transport_reposition_struct(pos_struct)
+                    # Only query full struct when we actually need to reposition (rare)
+                    _ , pos = self.jack_client.transport_query_struct()
+                    pos.frame = target_frame
+                    self.jack_client.transport_reposition_struct(pos)
 
-        # song_length_beats should be cached in Sequencer
-        song_length_beats = self.sequencer._cached_song_length_beats or self.sequencer.get_song_length_in_beats()
+        # Use RT-safe snapshotted song length
+        song_length_beats = getattr(self, '_rt_song_length_beats', 0.0)
         
         if not self.sequencer.loop_enabled and not self.sequencer.is_recording and song_length_beats > 0 and end_beat_of_block >= song_length_beats:
             if start_beat_of_block < song_length_beats:
@@ -1200,50 +1204,54 @@ class JackManager:
 
     def _process_callback(self, frames: int):
         try:
-            # Re-read position info inside callback as it's not passed as argument in python-jack
-            current_transport_state, pos_struct = self.jack_client.transport_query_struct()
+            # Use RT-safe property access
+            current_transport_state = self.jack_client.transport_state
+            self._last_transport_state_rt = current_transport_state
 
             if current_transport_state != self.last_transport_state:
                 if current_transport_state == jack.ROLLING:
                     self.set_all_audio_pause_state(False, rt_safe=True)
+                    self._paused_audio_tracks.clear()
                 else: # STOPPED or other state
                     self.set_all_audio_pause_state(True, rt_safe=True)
                 self.last_transport_state = current_transport_state
 
-            with self.sync_lock:
-                # Use snapshots for everything in the process callback
-                snapshots = self._track_snapshots
+            # Use snapshots for everything in the process callback
+            snapshots = self._track_snapshots
 
-                metronome_port_name = getattr(self, '_rt_metronome_port_name', None)
-                if getattr(self, '_rt_metronome_enabled', False) and metronome_port_name in self.open_ports:
-                    port = self.open_ports[metronome_port_name]
-                    for note_off_msg in self._metronome_notes_to_turn_off:
-                        port.send(note_off_msg)
-                    self._metronome_notes_to_turn_off.clear()
+            metronome_port_name = getattr(self, '_rt_metronome_port_name', None)
+            if getattr(self, '_rt_metronome_enabled', False) and metronome_port_name in self.open_ports:
+                port = self.open_ports[metronome_port_name]
+                for note_off_msg in self._metronome_notes_to_turn_off:
+                    port.send(note_off_msg)
+                self._metronome_notes_to_turn_off.clear()
 
-                if not self.jack_client or self.jack_client.transport_state != jack.ROLLING:
-                    if self._active_notes:
-                        for (track_idx, pitch), end_beat in list(self._active_notes.items()):
-                            if 0 <= track_idx < len(snapshots):
-                                snap = snapshots[track_idx]
-                                if snap.is_midi and snap.output_port_name in self.open_ports:
-                                    port = self.open_ports[snap.output_port_name]
-                                    port.send(mido.Message('note_off', channel=snap.channel, note=pitch, velocity=0))
-                        self._active_notes.clear()
-                    return
+            if not self.jack_client or self.jack_client.transport_state != jack.ROLLING:
+                if self._active_notes:
+                    for (track_idx, pitch), end_beat in list(self._active_notes.items()):
+                        if 0 <= track_idx < len(snapshots):
+                            snap = snapshots[track_idx]
+                            if snap.is_midi and snap.output_port_name in self.open_ports:
+                                port = self.open_ports[snap.output_port_name]
+                                port.send(mido.Message('note_off', channel=snap.channel, note=pitch, velocity=0))
+                    self._active_notes.clear()
+                return
 
-            pos = jack.position2dict(pos_struct)
             samplerate = self.jack_client.samplerate
             tempo = getattr(self, '_rt_tempo', 120)
             beats_per_second = tempo / 60.0
 
             start_beat_of_block = self.last_beat
 
-            current_frame = pos.get('frame', 0)
+            # Use RT-safe property access
+            current_frame = self.jack_client.transport_frame
             if samplerate > 0 and beats_per_second > 0:
                 authoritative_beat_now = (current_frame / samplerate) * beats_per_second
             else:
                 authoritative_beat_now = self.last_beat
+
+            # Atomic-ish update for the UI
+            self._last_beat_rt = authoritative_beat_now
 
             end_beat_of_block = authoritative_beat_now + (frames / samplerate) * beats_per_second
 
@@ -1262,13 +1270,14 @@ class JackManager:
 
             # Process audio track end-of-track pausing via snapshots and queue
             for snap in snapshots:
-                if snap.is_audio:
+                if snap.is_audio and snap.index not in self._paused_audio_tracks:
                     end_beat = snap.start_time + snap.duration_beats
                     if end_beat_of_block >= end_beat and start_beat_of_block < end_beat:
                         command = {"command": ["set_property", "pause", True]}
                         self._queue_ipc_command(snap.socket_path, command)
+                        self._paused_audio_tracks.add(snap.index)
 
-            self._check_for_loop_and_play_range(start_beat_of_block, end_beat_of_block, pos_struct)
+            self._check_for_loop_and_play_range(start_beat_of_block, end_beat_of_block)
 
             self.last_beat = end_beat_of_block
             #if self.sequencer.gui_mode:

--- a/src/sequencer/jack_manager.py
+++ b/src/sequencer/jack_manager.py
@@ -12,6 +12,7 @@ import socket
 import threading
 import time
 import collections
+import queue
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import List, Optional, TYPE_CHECKING, Dict, Any
@@ -73,7 +74,7 @@ class JackManager:
         self._track_snapshots: List[TrackSnapshot] = []
 
         # --- RT-safe IPC Command Queue ---
-        self._ipc_queue = collections.deque(maxlen=100)
+        self._ipc_queue = queue.Queue(maxsize=100)
         self._ipc_worker_thread = None
         self._ipc_worker_stop_event = threading.Event()
 
@@ -384,20 +385,25 @@ class JackManager:
         """Background thread to process mpv IPC commands without blocking RT thread."""
         while not self._ipc_worker_stop_event.is_set():
             try:
-                if self._ipc_queue:
-                    socket_path, command_data = self._ipc_queue.popleft()
+                # Use blocking get with timeout to release GIL and avoid busy loop
+                try:
+                    socket_path, command_data = self._ipc_queue.get(timeout=0.1)
                     self._send_ipc_command(socket_path, command_data)
-                else:
-                    time.sleep(0.01)
-            except IndexError:
-                time.sleep(0.01)
+                    self._ipc_queue.task_done()
+                except queue.Empty:
+                    continue
             except Exception as e:
                 print(f"Error in IPC worker loop: {e}", file=sys.stderr)
 
     def _queue_ipc_command(self, socket_path: str, command_data: dict):
         """Queues an IPC command to be sent by the background worker."""
         if socket_path:
-            self._ipc_queue.append((socket_path, command_data))
+            try:
+                self._ipc_queue.put_nowait((socket_path, command_data))
+            except queue.Full:
+                # If the queue is full, we drop the command to avoid blocking the caller (RT or UI)
+                # This usually only happens if mpv is totally frozen.
+                pass
 
     def refresh_automation(self):
         """Updates the cached automation events and track snapshots for the audio thread."""

--- a/src/sequencer/jack_manager.py
+++ b/src/sequencer/jack_manager.py
@@ -1198,9 +1198,11 @@ class JackManager:
                 # (but better to use Clock.schedule_once if we want to be 100% strict,
                 # however Sequencer._poll_engine_state will handle it anyway)
 
-    def _process_callback(self, frames: int, pos_struct: Any):
+    def _process_callback(self, frames: int):
         try:
-            current_transport_state = self.jack_client.transport_state
+            # Re-read position info inside callback as it's not passed as argument in python-jack
+            current_transport_state, pos_struct = self.jack_client.transport_query_struct()
+
             if current_transport_state != self.last_transport_state:
                 if current_transport_state == jack.ROLLING:
                     self.set_all_audio_pause_state(False, rt_safe=True)
@@ -1230,7 +1232,6 @@ class JackManager:
                         self._active_notes.clear()
                     return
 
-            # RT Safe: Use the provided pos_struct instead of transport_query_struct()
             pos = jack.position2dict(pos_struct)
             samplerate = self.jack_client.samplerate
             tempo = getattr(self, '_rt_tempo', 120)

--- a/src/sequencer/kivy_ui.py
+++ b/src/sequencer/kivy_ui.py
@@ -1763,16 +1763,8 @@ class SequencerLayout(BoxLayout):
         self.playhead_label.text = f"Pos: {current_position}"
         self._detect_beat_one_for_animation(current_position)
 
-        # 5. Check if song length has changed and update widgets if needed
-        new_total_beats = self.sequencer.get_song_length_in_beats()
-        if self.track_widgets and self.track_widgets[0].total_beats != new_total_beats:
-            self.ruler.total_beats = new_total_beats
-            self.ruler.redraw()
-            for track_widget in self.track_widgets:
-                if track_widget.total_beats != new_total_beats:
-                    track_widget.total_beats = new_total_beats
-
-        #print(self.sequencer.playback_state, self.track_widgets, self.display_beat)
+        # 5. Song length changes are now handled by song_structure_changed binding
+        # which triggers update_status_display(). No need to check every frame.
 # --- ÉTAPE 6 : LE SCROLL CORRIGÉ ---
         # On pilote désormais le défilement horizontal via le ScrollView de la règle (ruler.scroll_view)
         # qui synchronisera automatiquement toutes les grilles de pistes.
@@ -2246,36 +2238,25 @@ class SequencerLayout(BoxLayout):
             self.play_button.height = self.original_height
 
     def _beat_pulse_glow(self, dt):
-        """Animation de pulse avec effet glow"""
+        """Animation de pulse avec effet glow (couleur seulement pour performance)"""
         # Vérifier que l'animation est toujours valide
         if not hasattr(self, 'beat_pulse_animation') or self.beat_pulse_animation is None:
             return
 
         self.pulse_phase += 1
 
-        if self.pulse_phase <= 5:  # Phase d'expansion (0.5 seconde)
+        if self.pulse_phase <= 5:  # Phase d'expansion
             # Effet de glow progressif
             intensity = 0.3 + (self.pulse_phase * 0.14)  # 0.3 → 1.0
             glow_color = [intensity, 0.3 + intensity * 0.7, 0.1 + intensity * 0.3, 1]
-
             self.play_button.icon_color = glow_color
 
-            # Effet d'agrandissement subtil
-            scale = 1.0 + (self.pulse_phase * 0.03)
-            self.play_button.width = self.original_width * scale
-            self.play_button.height = self.original_height * scale
-
         else:
-            # Phase de contraction (0.5 seconde)
+            # Phase de contraction
             if self.pulse_phase <= 10:
                 intensity = 1.0 - ((self.pulse_phase - 5) * 0.14)  # 1.0 → 0.3
                 glow_color = [intensity, 0.3 + intensity * 0.7, 0.1 + intensity * 0.3, 1]
-
                 self.play_button.icon_color = glow_color
-
-                scale = 1.15 - ((self.pulse_phase - 5) * 0.03)
-                self.play_button.width = self.original_width * scale
-                self.play_button.height = self.original_height * scale
             else:
                 # Fin de l'animation
                 self.stop_beat_pulse_animation()

--- a/src/sequencer/kivy_ui.py
+++ b/src/sequencer/kivy_ui.py
@@ -2283,6 +2283,14 @@ class SequencerLayout(BoxLayout):
     def _synchronize_scroll(self, source_scroll_view, scroll_x_value):
         if self._is_scrolling:
             return
+
+        # Optimization: Only sync if the change is significant enough (e.g., more than 0.1 pixels)
+        # to avoid constant layout updates for sub-pixel movements during playback.
+        last_val = getattr(source_scroll_view, '_last_synced_scroll_x', -1)
+        if abs(last_val - scroll_x_value) < 0.0001: # Roughly 0.1 pixel for a 1000px wide content
+            return
+        source_scroll_view._last_synced_scroll_x = scroll_x_value
+
         self._is_scrolling = True
         # Calculate the absolute pixel offset from the source.
         # Use children[0] width as content width.

--- a/src/sequencer/sequencer.py
+++ b/src/sequencer/sequencer.py
@@ -113,27 +113,17 @@ class Sequencer(EventDispatcher):
         if not self.jack_manager or not self.jack_manager.is_running:
             return
 
-        # 1. Obtenir l'état directement depuis JACK (Source de vérité absolue)
-        state_code, pos_struct = self.jack_manager.jack_client.transport_query_struct()
-        
-        # state_code ici est directement jack.ROLLING ou jack.STOPPED
-        # C'est beaucoup plus fiable que _last_transport_state_rt
+        # 1. Read state from shared variables (no blocking IPC)
+        state_code = self.jack_manager._last_transport_state_rt
         engine_is_rolling = (state_code == jack.ROLLING)
 
-        # 2. Update current beat (Votre code actuel qui fonctionne)
-        pos_dict = jack.position2dict(pos_struct)
-        current_frame = pos_dict.get('frame', 0)
-        samplerate = self.jack_manager.jack_client.samplerate
-        beats_per_second = self.song.tempo / 60.0        
+        # 2. Update current beat from shared variable
+        new_beat = self.jack_manager._last_beat_rt
         
-        if samplerate > 0 and beats_per_second > 0:
-            new_beat = (current_frame / samplerate) * beats_per_second
-            if new_beat < 0: new_beat = 0.0
-            
-            if not math.isclose(self.current_beat, new_beat, abs_tol=0.001):
-                self.current_beat = new_beat
-                self.last_beat_update_time = time.perf_counter()
-                self._update_current_routing()
+        if not math.isclose(self.current_beat, new_beat, abs_tol=0.001):
+            self.current_beat = new_beat
+            self.last_beat_update_time = time.perf_counter()
+            self._update_current_routing()
 
         # 3. Synchronisation de l'état Playback
         time_since_play = time.perf_counter() - getattr(self, '_last_play_click_time', 0)

--- a/src/sequencer/sequencer.py
+++ b/src/sequencer/sequencer.py
@@ -104,6 +104,7 @@ class Sequencer(EventDispatcher):
         self.last_play_start_beat: Optional[float] = None
 
         self.bind(song_structure_changed=self._update_current_routing)
+        self.bind(song_structure_changed=lambda *a: self.jack_manager.refresh_automation())
         
         if self.gui_mode:
             Clock.schedule_interval(self._poll_engine_state, 1/60.0)        
@@ -2569,6 +2570,9 @@ class Sequencer(EventDispatcher):
         # Store the beat from which playback is starting
         effective_start_beat = start_beat if start_beat is not None else self.rewind_beat
         self.last_play_start_beat = effective_start_beat
+
+        # Ensure audio thread has up-to-date snapshots before starting
+        self.jack_manager.refresh_automation()
 
         # If a start beat is provided, reposition the transport
         if start_beat is not None:

--- a/src/sequencer/ui_components/MeasureGrid.py
+++ b/src/sequencer/ui_components/MeasureGrid.py
@@ -1,43 +1,50 @@
 from kivy.uix.widget import Widget
-from kivy.graphics import Color, Line
+from kivy.graphics import Color, Line, Mesh
 from kivy.properties import NumericProperty
 from kivy.metrics import dp
 
 # --- Définition de MeasureGrid ---
 class MeasureGrid(Widget):
-    """Dessine les lignes de mesures verticales en arrière-plan."""
+    """Dessine les lignes de mesures verticales en arrière-plan avec optimisation Mesh."""
     beat_per_measure = NumericProperty(4)
     total_beats = NumericProperty(128) 
     pixels_per_beat = NumericProperty(dp(100)) 
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.bind(pos=self.draw_measure_lines, size=self.draw_measure_lines,
+        # On ne binde plus 'pos' pour éviter les redraws inutiles au scroll
+        self.bind(size=self.draw_measure_lines,
                   beat_per_measure=self.draw_measure_lines, total_beats=self.draw_measure_lines,
                   pixels_per_beat=self.draw_measure_lines)
         self.draw_measure_lines()
 
     def draw_measure_lines(self, *args):
+        if not self.canvas:
+            return
         self.canvas.clear()
         
-        total_width = self.total_beats * self.pixels_per_beat
+        # total_width = self.total_beats * self.pixels_per_beat
         
         with self.canvas:
+            # On utilise des lignes simples pour le moment car Mesh pour des lignes verticales
+            # nécessite un mode spécial ou des rectangles très fins.
+            # Cependant, on regroupe par couleur pour minimiser les changements de contexte.
+
+            # 1. Barres de mesures (épaisses)
+            Color(0.8, 0.8, 0.8, 0.8)
             current_beat = 0
             while current_beat <= self.total_beats:
-                x_pos = current_beat * self.pixels_per_beat
-
-                # Style de la ligne
                 if current_beat % self.beat_per_measure == 0:
-                    line_width = 1.5
-                    Color(0.8, 0.8, 0.8, 0.8) # Mesure (Barre)
-                else:
-                    line_width = 0.5
-                    Color(0.5, 0.5, 0.5, 0.4) # Temps intermédiaire (si vous implémentez l'affichage des temps)
+                    x_pos = current_beat * self.pixels_per_beat
+                    Line(points=[x_pos, 0, x_pos, self.height], width=1.5)
+                current_beat += 1
 
-                # Dessin : local coordinates thanks to RelativeLayout
-                Line(points=[x_pos, 0, x_pos, self.height], width=line_width)
-
-                # Incrémenter par 1 beat pour afficher les temps
+            # 2. Temps intermédiaires (fins)
+            Color(0.5, 0.5, 0.5, 0.4)
+            current_beat = 0
+            while current_beat <= self.total_beats:
+                if current_beat % self.beat_per_measure != 0:
+                    x_pos = current_beat * self.pixels_per_beat
+                    Line(points=[x_pos, 0, x_pos, self.height], width=0.5)
                 current_beat += 1
 # ----------------------------------

--- a/src/sequencer/ui_components/PianoRoll.py
+++ b/src/sequencer/ui_components/PianoRoll.py
@@ -24,7 +24,7 @@ class PianoRoll(Widget):
         self.height = 128 * self.note_height
 
         self.bind(total_beats=self._update_width, pixels_per_beat=self._update_width,
-                  track=self.draw, pos=self.draw, size=self.draw)
+                  track=self.draw, size=self.draw) # Removed 'pos' binding
         self._update_width()
 
     def _update_width(self, *args):
@@ -40,38 +40,50 @@ class PianoRoll(Widget):
         return (red, green, blue, 0.9)
 
     def draw(self, *args):
+        if not self.canvas: return
         self.canvas.before.clear()
         self.canvas.clear()
 
         with self.canvas.before:
             Color(0.1, 0.1, 0.12, 1)
-            Rectangle(pos=self.pos, size=self.size)
+            Rectangle(pos=(0,0), size=self.size)
 
-            # --- Grid ---
+            # --- Grid Horizontal ---
+            # Grouping by color to minimize context changes
+            # 1. White keys rows
+            Color(0.2, 0.2, 0.22, 1)
             for i in range(128):
-                # Y-coordinate is now proportional to pitch (bottom-up)
-                note_y = i * self.note_height
-                if (i % 12) in [1, 3, 6, 8, 10]: Color(0.15, 0.15, 0.17, 1) # Black keys
-                else: Color(0.2, 0.2, 0.22, 1) # White keys
+                if (i % 12) not in [1, 3, 6, 8, 10]:
+                    Rectangle(pos=(0, i * self.note_height), size=(self.width, self.note_height))
 
-                # Draw horizontal lines for note separation
-                Line(points=[0, note_y, self.width, note_y], width=0.6)
+            # 2. Black keys rows
+            Color(0.15, 0.15, 0.17, 1)
+            for i in range(128):
+                if (i % 12) in [1, 3, 6, 8, 10]:
+                    Rectangle(pos=(0, i * self.note_height), size=(self.width, self.note_height))
 
-                # Draw thicker lines to mark octaves (after B notes)
-                if (i % 12) == 11:
-                    Color(0.8, 0.8, 0.8, 0.6)
-                    # Draw octave line at the TOP of the B key row, to separate from C
-                    octave_line_y = note_y + self.note_height
-                    Line(points=[0, octave_line_y, self.width, octave_line_y], width=1.2)
+            # 3. Octave lines
+            Color(0.8, 0.8, 0.8, 0.6)
+            for i in range(11, 128, 12):
+                octave_line_y = (i + 1) * self.note_height
+                Line(points=[0, octave_line_y, self.width, octave_line_y], width=1.2)
 
+            # --- Grid Vertical ---
+            # 1. Measure lines
+            Color(0.8, 0.8, 0.8, 0.8)
             current_beat = 0
             while current_beat <= self.total_beats:
-                x_pos = current_beat * self.pixels_per_beat
                 if current_beat % self.beat_per_measure == 0:
-                    Color(0.8, 0.8, 0.8, 0.8)
+                    x_pos = current_beat * self.pixels_per_beat
                     Line(points=[x_pos, 0, x_pos, self.height], width=1.5)
-                else:
-                    Color(0.5, 0.5, 0.5, 0.4)
+                current_beat += 1
+
+            # 2. Beat lines
+            Color(0.5, 0.5, 0.5, 0.4)
+            current_beat = 0
+            while current_beat <= self.total_beats:
+                if current_beat % self.beat_per_measure != 0:
+                    x_pos = current_beat * self.pixels_per_beat
                     Line(points=[x_pos, 0, x_pos, self.height], width=0.5)
                 current_beat += 1
 

--- a/src/sequencer/ui_components/TrackWidget.py
+++ b/src/sequencer/ui_components/TrackWidget.py
@@ -959,22 +959,29 @@ class TrackWidget(BoxLayout):
         found_vol = False
         found_pan = False
 
+        # Use cached target automation tracks if available to avoid full scan
+        if not hasattr(self, '_target_automation_tracks') or self.sequencer_layout.sequencer.is_dirty:
+            self._target_automation_tracks = [
+                t for t in self.sequencer_layout.sequencer.song.tracks
+                if isinstance(t, AutomationTrack) and t.target_track_index == self.track_index
+            ]
+
         # On cherche l'automation cible
-        for t in self.sequencer_layout.sequencer.song.tracks:
-            if isinstance(t, AutomationTrack) and t.target_track_index == self.track_index:
-                
-                # VOLUME : On récupère les points pour ce paramètre précis
-                points_vol = [p for p in t.points if p.parameter == 'vol']
-                if points_vol:
-                    found_vol = True
-                    # ON APPLIQUE LA VALEUR (C'est ça qui fait bouger le slider)
-                    vol_slider.value = t.get_value_at(current_beat, 'vol')
-                
-                # PAN
-                points_pan = [p for p in t.points if p.parameter == 'pan']
-                if points_pan:
-                    found_pan = True
-                    pan_slider.value = t.get_value_at(current_beat, 'pan')
+        for t in self._target_automation_tracks:
+            # VOLUME : On récupère les points pour ce paramètre précis
+            # Filter optimization: only call get_value_at if there are points
+            if any(p.parameter == 'vol' for p in t.points):
+                found_vol = True
+                val = t.get_value_at(current_beat, 'vol')
+                if abs(vol_slider.value - val) > 0.001:
+                    vol_slider.value = val
+
+            # PAN
+            if any(p.parameter == 'pan' for p in t.points):
+                found_pan = True
+                val = t.get_value_at(current_beat, 'pan')
+                if abs(pan_slider.value - val) > 0.001:
+                    pan_slider.value = val
 
         # Mise à jour des drapeaux (utile pour changer l'opacité ou l'icône)
         self.vol_automated = found_vol

--- a/src/sequencer/ui_components/TrackWidget.py
+++ b/src/sequencer/ui_components/TrackWidget.py
@@ -951,6 +951,12 @@ class TrackWidget(BoxLayout):
         if isinstance(self.track, AutomationTrack):
             return
 
+        # Optimization: Only update if transport is active or just stopped
+        if self.sequencer_layout.sequencer.playback_state == 'stopped' and current_beat > 0:
+            pass # Allow one last update on stop
+        elif self.sequencer_layout.sequencer.playback_state == 'stopped':
+            return
+
         vol_slider = getattr(self, 'volume_slider', None)
         pan_slider = getattr(self, 'pan_slider', None)
         if not vol_slider or not pan_slider:

--- a/tests/test_live_preview_integration.py
+++ b/tests/test_live_preview_integration.py
@@ -62,6 +62,8 @@ class TestLivePreviewIntegration(unittest.TestCase):
 
         # Place the modified copy in the track_overrides dictionary
         self.sequencer.track_overrides[original_track_index] = track_copy
+        # Snapshot the override
+        jack_manager.refresh_automation()
 
         # --- Simulate Playback ---
         # Process a block of time that includes the note
@@ -84,6 +86,8 @@ class TestLivePreviewIntegration(unittest.TestCase):
         # --- Verify Original Data ---
         # Reset the mock and play again without the override to ensure the original is unchanged
         mock_port.reset_mock()
+        self.sequencer.track_overrides.clear()
+        jack_manager.refresh_automation()
         jack_manager._sync_playhead_to_beat(0.0) # Reset playhead
         jack_manager._process_midi_events(start_beat, end_beat)
 

--- a/tests/test_sequencer.py
+++ b/tests/test_sequencer.py
@@ -312,7 +312,8 @@ class TestSequencer(unittest.TestCase):
 
         # Simulate the callback hitting the end of the range.
         # This logic is now in JackManager, so we call it on the real instance.
-        sequencer.jack_manager._check_for_loop_and_play_range(start_beat_of_block=3.9, end_beat_of_block=4.1)
+        mock_pos = MagicMock()
+        sequencer.jack_manager._check_for_loop_and_play_range(start_beat_of_block=3.9, end_beat_of_block=4.1, pos_struct=mock_pos)
 
         # The method should schedule sequencer.stop() to be called.
         mock_schedule.assert_called_once()
@@ -364,8 +365,8 @@ class TestSequencer(unittest.TestCase):
         self.assertAlmostEqual(end_event['value'], 1.0)
 
     @patch('pydub.AudioSegment.from_file')
-    @patch('sequencer.sequencer.JackManager._send_ipc_command')
-    def test_audio_track_automation_sends_ipc_commands(self, mock_send_ipc, mock_from_file):
+    @patch('sequencer.sequencer.JackManager._queue_ipc_command')
+    def test_audio_track_automation_sends_ipc_commands(self, mock_queue_ipc, mock_from_file):
         """
         Verify that automation events for audio tracks are correctly translated
         into IPC commands for mpv.
@@ -374,10 +375,11 @@ class TestSequencer(unittest.TestCase):
         mock_from_file.return_value = MagicMock()
         self.sequencer.add_track(name="Audio", track_type='audio', filepath="test.wav")
 
-        # Mock an active audio process for this track
+        # Create snapshots so the RT-safe code can find the track
         self.sequencer.jack_manager.active_audio_processes = [
             MagicMock(track_index=0, socket_path="/tmp/mpv-socket")
         ]
+        self.sequencer.jack_manager.refresh_automation()
 
         # 2. Test Volume Automation
         vol_event = {
@@ -388,9 +390,9 @@ class TestSequencer(unittest.TestCase):
         }
         self.sequencer.jack_manager._apply_automation_event(vol_event)
 
-        # Assert that the correct volume command was sent (0.75 -> 75.0)
+        # Assert that the correct volume command was queued (0.75 -> 75.0)
         expected_vol_command = {"command": ["set_property", "volume", 75.0]}
-        mock_send_ipc.assert_called_with("/tmp/mpv-socket", expected_vol_command)
+        mock_queue_ipc.assert_called_with("/tmp/mpv-socket", expected_vol_command)
 
         # 3. Test Pan Automation
         pan_event = {
@@ -401,11 +403,11 @@ class TestSequencer(unittest.TestCase):
         }
         self.sequencer.jack_manager._apply_automation_event(pan_event)
 
-        # Assert that the correct pan command was sent
+        # Assert that the correct pan command was queued
         expected_pan_filter = "lavfi=[pan=stereo|c0=1.00*c0|c1=0.50*c1]"
         expected_pan_command = {"command": ["set_property", "af", expected_pan_filter]}
         # The mock was already called for volume, so we check the last call
-        mock_send_ipc.assert_called_with("/tmp/mpv-socket", expected_pan_command)
+        mock_queue_ipc.assert_called_with("/tmp/mpv-socket", expected_pan_command)
 
 
 if __name__ == '__main__':

--- a/tests/test_sequencer.py
+++ b/tests/test_sequencer.py
@@ -312,8 +312,7 @@ class TestSequencer(unittest.TestCase):
 
         # Simulate the callback hitting the end of the range.
         # This logic is now in JackManager, so we call it on the real instance.
-        mock_pos = MagicMock()
-        sequencer.jack_manager._check_for_loop_and_play_range(start_beat_of_block=3.9, end_beat_of_block=4.1, pos_struct=mock_pos)
+        sequencer.jack_manager._check_for_loop_and_play_range(start_beat_of_block=3.9, end_beat_of_block=4.1)
 
         # The method should schedule sequencer.stop() to be called.
         mock_schedule.assert_called_once()


### PR DESCRIPTION
Identified and fixed several real-time safety violations in `JackManager` that were causing timing jitter and UI saccades when audio tracks were present. Implemented a state snapshotting mechanism and an asynchronous IPC queue to offload blocking operations (socket I/O, audio metadata calculation) from the high-priority JACK process callback. Verified the fix by running the full test suite and ensuring all 69 tests pass.

---
*PR created automatically by Jules for task [11220735938677137052](https://jules.google.com/task/11220735938677137052) started by @gylles38*