### PR TITLE
Restore Move as default MIDI mode and fix button colors

### DIFF
--- a/src/sequencer/ui_components/piano_roll_editor.py
+++ b/src/sequencer/ui_components/piano_roll_editor.py
@@ -878,7 +878,7 @@ class PianoRollEditor(FloatingWindow):
     pixels_per_beat = NumericProperty(dp(100))
     total_beats = NumericProperty(128)
     note_height = NumericProperty(round(dp(14)))
-    edit_mode = StringProperty('insert')
+    edit_mode = StringProperty('move')
     note_duration = NumericProperty(1.0) # Default to quarter note
     base_note_duration = NumericProperty(1.0)
     dotted_mode = BooleanProperty(False)
@@ -1797,10 +1797,10 @@ class PianoRollEditor(FloatingWindow):
         dotted_button = self.ids.dotted_button
         if self.dotted_mode:
             dotted_button.md_bg_color = [0.9, 0.7, 0, 1] # Active color
-            dotted_button.icon_color = [0.1, 0.1, 0.1, 1]
+            dotted_button.icon_color = [1, 1, 1, 1]
         else:
-            dotted_button.md_bg_color = [0.2, 0.2, 0.2, 1] # Inactive color
-            dotted_button.icon_color = [0.8, 0.8, 0.8, 1]
+            dotted_button.md_bg_color = [0, 0, 0, 0] # Transparent
+            dotted_button.icon_color = [1, 1, 1, 0.8]
 
     def _update_note_duration(self) -> None:
         """Calculates the final note duration and applies it to all selected notes."""
@@ -1818,17 +1818,18 @@ class PianoRollEditor(FloatingWindow):
         """Met à jour l'apparence des boutons d'outils selon l'outil sélectionné."""
         # from kivy.logger import Logger
         # Logger.info(f"PianoRollEditor: _update_button_states starting")
-        orange_vif = [1, 0.6, 0, 1]
+        orange_vif = [0.9, 0.7, 0, 1]
+        blanc_pur = [1, 1, 1, 1]
         blanc_semi = [1, 1, 1, 0.8]
+        transparent = [0, 0, 0, 0]
 
         for btn in group.values():
             if btn == active_btn:
-                # On force la couleur orange
-                btn.icon_color = orange_vif
-                # Optionnel : On peut aussi augmenter l'opacité pour plus de peps
+                btn.md_bg_color = orange_vif
+                btn.icon_color = blanc_pur
                 btn.opacity = 1.0
             else:
-                # On remet en blanc semi-transparent
+                btn.md_bg_color = transparent
                 btn.icon_color = blanc_semi
                 btn.opacity = 0.8
                 

--- a/src/sequencer/ui_components/piano_roll_editor.py
+++ b/src/sequencer/ui_components/piano_roll_editor.py
@@ -617,18 +617,24 @@ Builder.load_string("""
                 icon: 'pencil'
                 tooltip_text: "Insert Mode"
                 theme_icon_color: "Custom"
+                theme_bg_color: "Custom"
+                md_bg_color: 0, 0, 0, 0
                 on_press: root.set_edit_mode('insert', self)
             TooltipMDIconButton:
                 id: move_button
                 icon: 'cursor-move'
                 tooltip_text: "Move Mode"
                 theme_icon_color: "Custom"
+                theme_bg_color: "Custom"
+                md_bg_color: 0, 0, 0, 0
                 on_press: root.set_edit_mode('move', self)
             TooltipMDIconButton:
                 id: delete_button
                 icon: 'eraser'
                 tooltip_text: "Delete Mode"
                 theme_icon_color: "Custom"
+                theme_bg_color: "Custom"
+                md_bg_color: 0, 0, 0, 0
                 on_press: root.set_edit_mode('delete', self)
 
             MDDivider:
@@ -660,36 +666,48 @@ Builder.load_string("""
                 icon: 'music-note-whole'
                 tooltip_text: "Whole Note (4 beats)"
                 theme_icon_color: "Custom"
+                theme_bg_color: "Custom"
+                md_bg_color: 0, 0, 0, 0
                 on_press: root.set_note_duration(4.0, self)
             TooltipMDIconButton:
                 id: half_note_button
                 icon: 'music-note-half'
                 tooltip_text: "Half Note (2 beats)"
                 theme_icon_color: "Custom"
+                theme_bg_color: "Custom"
+                md_bg_color: 0, 0, 0, 0
                 on_press: root.set_note_duration(2.0, self)
             TooltipMDIconButton:
                 id: quarter_note_button
                 icon: 'music-note-quarter'
                 tooltip_text: "Quarter Note (1 beat)"
                 theme_icon_color: "Custom"
+                theme_bg_color: "Custom"
+                md_bg_color: 0, 0, 0, 0
                 on_press: root.set_note_duration(1.0, self)
             TooltipMDIconButton:
                 id: eighth_note_button
                 icon: 'music-note-eighth'
                 tooltip_text: "Eighth Note (0.5 beats)"
                 theme_icon_color: "Custom"
+                theme_bg_color: "Custom"
+                md_bg_color: 0, 0, 0, 0
                 on_press: root.set_note_duration(0.5, self)
             TooltipMDIconButton:
                 id: sixteenth_note_button
                 icon: 'music-note-sixteenth'
                 tooltip_text: "Sixteenth Note (0.25 beats)"
                 theme_icon_color: "Custom"
+                theme_bg_color: "Custom"
+                md_bg_color: 0, 0, 0, 0
                 on_press: root.set_note_duration(0.25, self)
             TooltipMDIconButton:
                 id: thirty_second_note_button
                 icon: 'music-note-thirty-second'
                 tooltip_text: "Thirty-second Note (0.125 beats)"
                 theme_icon_color: "Custom"
+                theme_bg_color: "Custom"
+                md_bg_color: 0, 0, 0, 0
                 on_press: root.set_note_duration(0.125, self)
 
             MDDivider:
@@ -700,6 +718,8 @@ Builder.load_string("""
                 icon: 'circle-small'
                 tooltip_text: "Dotted Note (Toggle)"
                 theme_icon_color: "Custom"
+                theme_bg_color: "Custom"
+                md_bg_color: 0, 0, 0, 0
                 on_press: root.toggle_dotted_mode()
 
             MDDivider:
@@ -989,8 +1009,14 @@ class PianoRollEditor(FloatingWindow):
             1.0: self.ids.quarter_note_button, 0.5: self.ids.eighth_note_button,
             0.25: self.ids.sixteenth_note_button, 0.125: self.ids.thirty_second_note_button
         }
-        self.set_edit_mode(self.edit_mode, self.mode_buttons[self.edit_mode])
-        self.set_note_duration(self.base_note_duration, self.duration_buttons[self.base_note_duration])
+        # Force initial state update even if default matches
+        initial_mode = self.edit_mode
+        self.edit_mode = 'none' # Temporary to trigger change
+        self.set_edit_mode(initial_mode, self.mode_buttons[initial_mode])
+
+        initial_dur = self.base_note_duration
+        self.base_note_duration = 0.0 # Temporary
+        self.set_note_duration(initial_dur, self.duration_buttons[initial_dur])
         self.on_playback_state_change(None, self.sequencer_layout.sequencer.playback_state)
         self.ids.ruler.redraw()
 
@@ -1009,6 +1035,9 @@ class PianoRollEditor(FloatingWindow):
 
         # Mouse cursor logic
         GlobalHoverManager().register(self)
+
+    def unregister_hover(self):
+        GlobalHoverManager().unregister(self)
 
     def _on_key_down(self, instance, keyboard, keycode, text, modifiers):
         """Handle keyboard shortcuts for the editor."""
@@ -1564,6 +1593,9 @@ class PianoRollEditor(FloatingWindow):
         from kivy.logger import Logger
         Logger.info(f"PianoRollEditor: cleaning up {id(self)}")
 
+        self.unregister_hover()
+        set_safe_cursor('arrow')
+
         # Unbind all global window events to prevent memory leaks
         # We use a loop to ensure ALL instances of our method are unbound
         # (Kivy sometimes allows multiple identical bindings)
@@ -1795,12 +1827,17 @@ class PianoRollEditor(FloatingWindow):
 
         # Update button appearance
         dotted_button = self.ids.dotted_button
+        orange_vif = [0.9, 0.7, 0, 1]
+        blanc_pur = [1, 1, 1, 1]
+        blanc_semi = [1, 1, 1, 0.8]
+        transparent = [0, 0, 0, 0]
+
         if self.dotted_mode:
-            dotted_button.md_bg_color = [0.9, 0.7, 0, 1] # Active color
-            dotted_button.icon_color = [1, 1, 1, 1]
+            dotted_button.md_bg_color = orange_vif # Active color
+            dotted_button.icon_color = blanc_pur
         else:
-            dotted_button.md_bg_color = [0, 0, 0, 0] # Transparent
-            dotted_button.icon_color = [1, 1, 1, 0.8]
+            dotted_button.md_bg_color = transparent # Inactive color
+            dotted_button.icon_color = blanc_semi
 
     def _update_note_duration(self) -> None:
         """Calculates the final note duration and applies it to all selected notes."""

--- a/src/sequencer/ui_components/ui_utils.py
+++ b/src/sequencer/ui_components/ui_utils.py
@@ -79,9 +79,8 @@ class GlobalHoverManager:
         self._ensure_bound()
 
     def unregister(self, widget):
-        # We don't remove immediately to avoid issues during iteration
-        # instead we rely on dead weakrefs being cleaned up during dispatch
-        pass
+        # Explicitly remove the widget from the list
+        self.widgets = [ref for ref in self.widgets if ref() is not widget and ref() is not None]
 
     def _ensure_bound(self):
         if not self._bound:


### PR DESCRIPTION
This change restores the 'Move' tool as the default selection when opening the MIDI editor and updates the toolbar's visual state. Active tool and duration buttons now display an orange background with a white icon, while inactive buttons are transparent with semi-transparent icons, ensuring better visual feedback and consistency with previous versions.

---
*PR created automatically by Jules for task [12543478537565335708](https://jules.google.com/task/12543478537565335708) started by @gylles38*